### PR TITLE
BAH-3771 | Use location with organization tag for Organization resource in FHIR bundle

### DIFF
--- a/omod/src/main/java/org/bahmni/module/hip/web/service/FhirBundledDiagnosticReportBuilder.java
+++ b/omod/src/main/java/org/bahmni/module/hip/web/service/FhirBundledDiagnosticReportBuilder.java
@@ -8,6 +8,7 @@ import org.bahmni.module.hip.web.model.OpenMrsDiagnosticReport;
 import org.bahmni.module.hip.web.model.OpenMrsLabResults;
 import org.bahmni.module.hip.web.model.OrganizationContext;
 import org.hl7.fhir.r4.model.Bundle;
+import org.openmrs.Location;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -28,7 +29,8 @@ public class FhirBundledDiagnosticReportBuilder {
     }
 
     public DiagnosticReportBundle fhirBundleResponseFor(OpenMrsDiagnosticReport openMrsDiagnosticReport) {
-        OrganizationContext organizationContext = organizationContextService.buildContext(Optional.ofNullable(openMrsDiagnosticReport.getEncounter().getVisit().getLocation()));
+        Optional<Location> location = OrganizationContextService.findOrganization(openMrsDiagnosticReport.getEncounter().getVisit().getLocation());
+        OrganizationContext organizationContext = organizationContextService.buildContext(location);
 
         Bundle diagnosticReportBundle = FhirDiagnosticReport
                 .fromOpenMrsDiagnosticReport(openMrsDiagnosticReport, fhirResourceMapper)
@@ -45,7 +47,8 @@ public class FhirBundledDiagnosticReportBuilder {
     }
 
     public DiagnosticReportBundle fhirBundleResponseFor(OpenMrsLabResults results) {
-        OrganizationContext organizationContext = organizationContextService.buildContext(Optional.ofNullable(results.getEncounter().getVisit().getLocation()));
+        Optional<Location> location = OrganizationContextService.findOrganization(results.getEncounter().getVisit().getLocation());
+        OrganizationContext organizationContext = organizationContextService.buildContext(location);
 
         Bundle diagnosticReportBundle = FhirLabResult.fromOpenMrsLabResults(results, fhirResourceMapper)
                 .bundleLabResults(organizationContext, fhirResourceMapper);

--- a/omod/src/main/java/org/bahmni/module/hip/web/service/FhirBundledDischargeSummaryBuilder.java
+++ b/omod/src/main/java/org/bahmni/module/hip/web/service/FhirBundledDischargeSummaryBuilder.java
@@ -2,6 +2,7 @@ package org.bahmni.module.hip.web.service;
 
 import org.bahmni.module.hip.web.model.*;
 import org.hl7.fhir.r4.model.Bundle;
+import org.openmrs.Location;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -25,8 +26,8 @@ public class FhirBundledDischargeSummaryBuilder {
     }
 
     public DischargeSummaryBundle fhirBundleResponseFor (OpenMrsDischargeSummary openMrsDischargeSummary) {
-        OrganizationContext organizationContext = organizationContextService.buildContext(
-                Optional.ofNullable(openMrsDischargeSummary.getEncounter().getVisit().getLocation()));
+        Optional<Location> location = OrganizationContextService.findOrganization(openMrsDischargeSummary.getEncounter().getVisit().getLocation());
+        OrganizationContext organizationContext = organizationContextService.buildContext(location);
 
         Bundle dischargeSummaryBundle = FhirDischargeSummary.fromOpenMrsDischargeSummary(openMrsDischargeSummary, fhirResourceMapper, abdmConfig, omrsObsDocumentTransformer).
                 bundleDischargeSummary(organizationContext);

--- a/omod/src/main/java/org/bahmni/module/hip/web/service/FhirBundledOPConsultBuilder.java
+++ b/omod/src/main/java/org/bahmni/module/hip/web/service/FhirBundledOPConsultBuilder.java
@@ -6,6 +6,7 @@ import org.bahmni.module.hip.web.model.OPConsultBundle;
 import org.bahmni.module.hip.web.model.OpenMrsOPConsult;
 import org.bahmni.module.hip.web.model.OrganizationContext;
 import org.hl7.fhir.r4.model.Bundle;
+import org.openmrs.Location;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -29,7 +30,8 @@ public class FhirBundledOPConsultBuilder {
     }
 
     public OPConsultBundle fhirBundleResponseFor (OpenMrsOPConsult openMrsOPConsult) {
-        OrganizationContext organizationContext = organizationContextService.buildContext(Optional.ofNullable(openMrsOPConsult.getEncounter().getVisit().getLocation()));
+        Optional<Location> location = OrganizationContextService.findOrganization(openMrsOPConsult.getEncounter().getVisit().getLocation());
+        OrganizationContext organizationContext = organizationContextService.buildContext(location);
         Bundle opConsultBundle = FhirOPConsult.fromOpenMrsOPConsult(openMrsOPConsult, fhirResourceMapper, abdmConfig, omrsObsDocumentTransformer).
                 bundleOPConsult(organizationContext);
         CareContext careContext = careContextService.careContextFor(

--- a/omod/src/main/java/org/bahmni/module/hip/web/service/FhirBundledPrescriptionBuilder.java
+++ b/omod/src/main/java/org/bahmni/module/hip/web/service/FhirBundledPrescriptionBuilder.java
@@ -6,6 +6,7 @@ import org.bahmni.module.hip.web.model.OpenMrsPrescription;
 import org.bahmni.module.hip.web.model.OrganizationContext;
 import org.bahmni.module.hip.web.model.PrescriptionBundle;
 import org.hl7.fhir.r4.model.Bundle;
+import org.openmrs.Location;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -28,7 +29,8 @@ public class FhirBundledPrescriptionBuilder {
 
     PrescriptionBundle fhirBundleResponseFor(OpenMrsPrescription openMrsPrescription) {
 
-        OrganizationContext organizationContext = organizationContextService.buildContext(Optional.ofNullable(openMrsPrescription.getEncounter().getVisit().getLocation()));
+        Optional<Location> location = OrganizationContextService.findOrganization(openMrsPrescription.getEncounter().getVisit().getLocation());
+        OrganizationContext organizationContext = organizationContextService.buildContext(location);
 
         Bundle prescriptionBundle = FhirPrescription
                 .from(openMrsPrescription, fhirResourceMapper, documentTransformer)


### PR DESCRIPTION
This PR fixes the inconsistency with choosing the location to create the Organization for resource type. Now for all the Hi-Types, location is selected as below and organisation resource in FHIR bundle is constructed accordingly.

https://bahmni.atlassian.net/wiki/spaces/BAH/pages/3162079253/Support+for+Health+Information+Types#Configure-Authoring-Organization-for-documents