### PR TITLE
BAH-4120 | Fix. Avoid opening session on existingPatient search

### DIFF
--- a/api/src/main/java/org/bahmni/module/hip/api/dao/impl/ExistingPatientDaoImpl.java
+++ b/api/src/main/java/org/bahmni/module/hip/api/dao/impl/ExistingPatientDaoImpl.java
@@ -28,7 +28,7 @@ public class ExistingPatientDaoImpl implements ExistingPatientDao {
         String getPatientWithHealthIdQuery = "SELECT p.uuid FROM person AS p INNER JOIN \n" +
                 "\t\t\t\t   patient_identifier AS pi ON p.person_id = pi.patient_id \n" +
                 "\t\t\t\t   WHERE identifier = :healthId ;";
-        Query query = this.sessionFactory.openSession().createSQLQuery(getPatientWithHealthIdQuery);
+        Query query = this.sessionFactory.getCurrentSession().createSQLQuery(getPatientWithHealthIdQuery);
         query.setParameter("healthId", healthId);
         List<String> patientUuids = query.list();
         return patientUuids.size() > 0 ? patientUuids.get(0) : null;


### PR DESCRIPTION
This PR fixes the performance issue with the `/ws/rest/v1/hip/existingPatients/{healthId}` API which makes the OpenMRS service to go down on concurrent hits.

Instead of `openSession` we are using `getCurrentSession` which closes the session on closing of the context.

Found while testing: https://bahmni.atlassian.net/browse/BAH-4120