### PR TITLE
BAH-4147 | Fix. Link identifier only when identifier value is passed

### DIFF
--- a/api/src/main/java/org/bahmni/module/hip/service/impl/ExistingPatientServiceImpl.java
+++ b/api/src/main/java/org/bahmni/module/hip/service/impl/ExistingPatientServiceImpl.java
@@ -79,13 +79,15 @@ public class ExistingPatientServiceImpl implements ExistingPatientService {
     }
 
     private void setIdentifier(Patient patient, String identifierValue, String identifierType) {
-        PatientIdentifier identifier = new PatientIdentifier();
+        if(identifierValue != null && !identifierValue.isEmpty()) {
+            PatientIdentifier identifier = new PatientIdentifier();
 
-        identifier.setPatient(patient);
-        identifier.setIdentifier(identifierValue);
-        identifier.setIdentifierType(patientService.getPatientIdentifierTypeByName(identifierType));
+            identifier.setPatient(patient);
+            identifier.setIdentifier(identifierValue);
+            identifier.setIdentifierType(patientService.getPatientIdentifierTypeByName(identifierType));
 
-        patientService.savePatientIdentifier(identifier);
+            patientService.savePatientIdentifier(identifier);
+        }
     }
 
 


### PR DESCRIPTION
This PR fixes the exception thrown when the Identifier update API is called with null or empty identifier value.